### PR TITLE
added check on pop(0), when operating on list length 0.

### DIFF
--- a/pymc3/plots.py
+++ b/pymc3/plots.py
@@ -906,7 +906,8 @@ def tree_layout(graph):
     assert len(roots) == len(depth_positions[0])
     for root in roots:
         root_depth = depths[root]
-        positions[root] = (depth_positions[root_depth].pop(0), root_depth)
+        if depth_positions[root_depth]:
+            positions[root] = (depth_positions[root_depth].pop(0), root_depth)
         for node in graph.nodes():
             if node not in positions:
                 node_depth = depths[node]


### PR DESCRIPTION
Tree creation was failing when pop was called on an empty list. Used example Bayes-net from [this gist](https://gist.github.com/tbsexton/1349864212b25cce91dbe5e336d794b4). 

On another note, however, the actual generated tree doesn't look quite right. 
![pmml_bayesnet_tree](https://cloud.githubusercontent.com/assets/12550525/22988695/03c5e4cc-f381-11e6-88bd-b9e6c1088230.png)

vs 

![pmml_bayesnet_true](https://camo.githubusercontent.com/8cf47b27acd9d8e301d2ccbe292892f22d6ac0ff/687474703a2f2f646d672e6f72672f706d6d6c2f76342d332f424e4578616d706c654d6f64656c2e706e67)
